### PR TITLE
Fix typos in system prompt

### DIFF
--- a/query.py
+++ b/query.py
@@ -37,9 +37,9 @@ def project_name_extraction(user_input: str) -> ProjectExtraction:
         messages=[
             {
                 "role": "system",
-                "content": """Analyze the query text andasnwer if the query is related to a project.
+                "content": """Analyze the query text and answer if the query is related to a project.
 
-                Possible proects are SPECTRO, EMAI4EU, RESCHIP4EU and ACHIEVE.
+                Possible projects are SPECTRO, EMAI4EU, RESCHIP4EU and ACHIEVE.
                 """,
             },
             {"role": "user", "content": user_input},


### PR DESCRIPTION
## Summary
- correct typos in the system message of `project_name_extraction`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4d3709fc83299b5d242a5bd296b9